### PR TITLE
fix warnings

### DIFF
--- a/ldns-zone-digest.c
+++ b/ldns-zone-digest.c
@@ -896,7 +896,7 @@ do_verify(void)
 void
 probe_ldns(const char *origin_str)
 {
-	ldns_rr *rr = NULL;
+	ldns_rr *rr = 0;
 	ldns_rdf *origin = ldns_rdf_new_frm_str(LDNS_RDF_TYPE_DNAME, origin_str);
 	ldns_status status = ldns_rr_new_frm_str (&rr, "test 300 IN ZONEMD 123456789 2 0 deadbeef", 0, origin, 0);
 	fdebugf(stderr, "%s(%d): probe_ldns: %s\n", __FILE__, __LINE__, ldns_get_errorstr_by_id(status));

--- a/ldns-zone-digest.c
+++ b/ldns-zone-digest.c
@@ -896,7 +896,7 @@ do_verify(void)
 void
 probe_ldns(const char *origin_str)
 {
-	ldns_rr *rr;
+	ldns_rr *rr = NULL;
 	ldns_rdf *origin = ldns_rdf_new_frm_str(LDNS_RDF_TYPE_DNAME, origin_str);
 	ldns_status status = ldns_rr_new_frm_str (&rr, "test 300 IN ZONEMD 123456789 2 0 deadbeef", 0, origin, 0);
 	fdebugf(stderr, "%s(%d): probe_ldns: %s\n", __FILE__, __LINE__, ldns_get_errorstr_by_id(status));

--- a/ldns-zone-digest.c
+++ b/ldns-zone-digest.c
@@ -8,21 +8,21 @@
  *
  * Copyright (c) 2018, Verisign, Inc.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * * Redistributions of source code must retain the above copyright notice, this
  *   list of conditions and the following disclaimer.
- * 
+ *
  * * Redistributions in binary form must reproduce the above copyright notice,
  *   this list of conditions and the following disclaimer in the documentation
  *   and/or other materials provided with the distribution.
- * 
+ *
  * * Neither the name of the copyright holder nor the names of its
  *   contributors may be used to endorse or promote products derived from
  *   this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -351,7 +351,7 @@ zonemd_rr_unpack(ldns_rr *rr, uint32_t *ret_serial, uint8_t *ret_digest_type, vo
 }
 
 /*
- * zonemd_rr_update_digest() 
+ * zonemd_rr_update_digest()
  *
  * Updates the digest part of a placeholder ZONEMD record.  If the new_digest_buf pointer is NULL, the
  * digest value is set to all zeroes.


### PR DESCRIPTION
my ldns build set "CPPFLAGS=-Wall -Wunused-parameter -Wstrict-prototypes -Wsign-compare"
With this patch the build produce no warnings at all.

DISCLAIMER: I'm not a programmer! Please verify if the patch introduce any other issues...